### PR TITLE
Fix Spanish comment formatting in converter.sh

### DIFF
--- a/converter.sh
+++ b/converter.sh
@@ -3,7 +3,7 @@
 
 shopt -s globstar nullglob   # ** habilita recursividad en bash ≥4
 for file in **/*.docx; do
-  # - Extrae imágenes a una subcarpeta “media” junto al .md (opcional)
+  # - Extrae imágenes a una subcarpeta "media" junto al .md (opcional)
   # - Sustituye la extensión conservando la ruta original
   pandoc -f docx -t gfm               \
          --extract-media="${file%/*}/media" \


### PR DESCRIPTION
## Summary
- adjust Spanish comments in `converter.sh` to use standard quotes

## Testing
- `bash -n converter.sh`


------
https://chatgpt.com/codex/tasks/task_e_685d93d2301c83318d972f8db9dfce2e